### PR TITLE
ZO-1609: Implement webhook receiver for "Parse API"

### DIFF
--- a/watchdog/watchdog.ini.sample
+++ b/watchdog/watchdog.ini.sample
@@ -1,13 +1,8 @@
 [briefkasten]
 app_url = http://localhost:6543/briefkasten/
 max_process_secs = 60
-imap_recipient = 
-imap_host = 
-imap_user = 
-imap_passwd = 
 testing_secret = 
 the_sender= 
-notify_email = 
 # smtp settings for pyramid_mailer, see
 # http://docs.pylonsproject.org/projects/pyramid_mailer/en/latest/
 smtp_host = localhost


### PR DESCRIPTION
Hiermit wird ein einfacher Empfänger für MailJets "[Parse API](https://dev.mailjet.com/email/guides/parse-api/)" implementiert, die in Zukunft anstatt IMAP verwendet wird.

Siehe [ZO-1609](https://zeit-online.atlassian.net/browse/ZO-1609) & https://github.com/ZeitOnline/briefkasten-config/pull/2.