### PR TITLE
feat(watchdog): extend prometheus metrics

### DIFF
--- a/watchdog/src/watchdog/briefkasten_watchdog/__init__.py
+++ b/watchdog/src/watchdog/briefkasten_watchdog/__init__.py
@@ -20,6 +20,14 @@ last_success = Gauge(
     'job_last_briefkasten_watchdog_success_unixtime',
     'Last time a briefkasten watchdog job successfully finished',
     registry=REGISTRY)
+last_test_submission = Gauge(
+    'briefkasten_watchdog_last_test_submission_unixtime',
+    'Unix timestamp of the last test submission',
+    registry=REGISTRY)
+pending_test_submission_count = Gauge(
+    'briefkasten_watchdog_pending_test_submission_count',
+    'Number of test submissions that have not been acknowledged yet',
+    registry=REGISTRY)
 
 
 def perform_submission(app_url, testing_secret):
@@ -74,10 +82,19 @@ def receive_test_submissions(handler):
         httpd.serve_forever()
 
 
-def push_to_prometheus(config):
+def update_metrics(dbm_path):
+    with dbm_open(dbm_path, 'c') as db:
+        sent_dates = list(map(float, db.values()))
+    pending_test_submission_count.set(len(sent_dates))
+    last_test_submission.set(max(sent_dates, default=0))
+
+
+def push_to_prometheus():
+    gateway_url = environ.get('BKWD_prometheus_push_gateway_url')
+    environment = environ.get('BKWD_environment')
     push_to_gateway(
-        config['prometheus_push_gateway_url'],
-        job="briefkasten_watchdog_{environment}".format(**config),
+        gateway_url,
+        job=f"briefkasten_watchdog_{environment}",
         registry=REGISTRY)
 
 
@@ -96,6 +113,8 @@ def submit(app_url, testing_secret, dbm_path):
     token = perform_submission(app_url, testing_secret)
     with dbm_open(dbm_path, 'c') as db:
         db[token.encode()] = str(time())
+    update_metrics(dbm_path)
+    push_to_prometheus()
     log.info("Created drop with token %s", token)
 
 
@@ -124,6 +143,8 @@ def receive(dbm_path, pattern, max_process_secs):
                         log.warning("[Slow test submission] The submission with token '%s' "
                                     "which was submitted on %s was not received after %d seconds.",
                                     token.decode(), datetime.fromtimestamp(sent), max_process_secs)
+            update_metrics(dbm_path)
+            push_to_prometheus()
     # start http server passing the handler
     receive_test_submissions(handler)
 
@@ -138,4 +159,6 @@ def prune(dbm_path, days):
         old = [token for token in db.keys() if db[token] < cutoff]
         for token in old:
             del db[token]
+    update_metrics(dbm_path)
+    push_to_prometheus()
     log.info("Pruned %s old tokens", len(old))

--- a/watchdog/src/watchdog/briefkasten_watchdog/__init__.py
+++ b/watchdog/src/watchdog/briefkasten_watchdog/__init__.py
@@ -17,7 +17,7 @@ log.setLevel(environ.get('BKWD_LOG_LEVEL', 'info').upper())
 
 REGISTRY = CollectorRegistry()
 last_success = Gauge(
-    'job_last_briefkasten_watchdog_success_unixtime',
+    'briefkasten_watchdog_last_success_unixtime',
     'Last time a briefkasten watchdog job successfully finished',
     registry=REGISTRY)
 last_test_submission = Gauge(

--- a/watchdog/src/watchdog/briefkasten_watchdog/__init__.py
+++ b/watchdog/src/watchdog/briefkasten_watchdog/__init__.py
@@ -112,7 +112,7 @@ def submit(app_url, testing_secret, dbm_path):
     log.debug("Performing test submissions against %s", app_url)
     token = perform_submission(app_url, testing_secret)
     with dbm_open(dbm_path, 'c') as db:
-        db[token.encode()] = str(time())
+        db[token] = str(time())
     update_metrics(dbm_path)
     push_to_prometheus()
     log.info("Created drop with token %s", token)
@@ -154,9 +154,9 @@ def receive(dbm_path, pattern, max_process_secs):
 @option('--days', default=7, help='number of days to keep')
 def prune(dbm_path, days):
     """ Prune old test submission tokens """
-    cutoff = str(time() - days * 86_400).encode()
+    cutoff = time() - days * 86_400
     with dbm_open(dbm_path, 'c') as db:
-        old = [token for token in db.keys() if db[token] < cutoff]
+        old = [token for token in db.keys() if float(db[token]) < cutoff]
         for token in old:
             del db[token]
     update_metrics(dbm_path)

--- a/watchdog/src/watchdog/briefkasten_watchdog/__init__.py
+++ b/watchdog/src/watchdog/briefkasten_watchdog/__init__.py
@@ -90,8 +90,8 @@ def update_metrics(dbm_path):
 
 
 def push_to_prometheus():
-    gateway_url = environ.get('BKWD_prometheus_push_gateway_url')
-    environment = environ.get('BKWD_environment')
+    gateway_url = environ.get('BKWD_PROMETHEUS_PUSH_GATEWAY_URL')
+    environment = environ.get('BKWD_ENVIRONMENT')
     push_to_gateway(
         gateway_url,
         job=f"briefkasten_watchdog_{environment}",


### PR DESCRIPTION
Two new metrics with the timestamp of the last test submission as
well as the count of unacknowledged test submissions are added.

Refs: ENG-78